### PR TITLE
Apply JVM target compatibility

### DIFF
--- a/datetime-wheel-picker/build.gradle.kts
+++ b/datetime-wheel-picker/build.gradle.kts
@@ -25,7 +25,15 @@ kotlin {
     }
   }
 
-  jvm()
+  jvm {
+    compilations.all {
+      compileTaskProvider.configure {
+        compilerOptions {
+          jvmTarget.set(JvmTarget.JVM_17)
+        }
+      }
+    }
+  }
 
   js {
     browser()


### PR DESCRIPTION
Currently the library is only setting JVM target compatibility for `androidTarget` and not for the `jvm` (desktop) target, causing a runtime error on projects that use an older JVM than the one this library was built with.

This change updates the setting for `jvm` to align it with the Android target, which is currently set to 17.